### PR TITLE
Anon comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -78,6 +78,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:content, :archived)
+    params.require(:comment).permit(:content, :archived, :anonymous)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,9 @@ class CommentsController < ApplicationController
     @comment = @announcement.comments.build(comment_params)
     @comment.user = current_user
 
+    # Ensure admin can't post an anonymous comment
+    @comment.anonymous = false if current_user.admin?
+
     if @comment.save
       redirect_to(@announcement, notice: 'Comment was successfully created.')
     else

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -35,10 +35,12 @@
       <%= form.text_area :content, id: "comment_box" %>
     </div>
 
-    <div>
-      <%= form.label :anonymous, "Post anonymously" %>
-      <%= form.check_box :anonymous %>
-    </div>
+    <% unless current_user&.admin? %>
+      <div>
+        <%= form.label :anonymous, "Post anonymously" %>
+        <%= form.check_box :anonymous %>
+      </div>
+    <% end %>
 
     <div>
       <%= form.submit "Add Comment" %>

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -36,6 +36,11 @@
     </div>
 
     <div>
+      <%= form.label :anonymous, "Post anonymously" %>
+      <%= form.check_box :anonymous %>
+    </div>
+
+    <div>
       <%= form.submit "Add Comment" %>
     </div>
   <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,8 +5,10 @@
     <br>
     <p>
       <strong>User:</strong>
+      <!-- Only show "Anonymous" to Non-Admin members who are not the comment author -->
       <% if comment.anonymous && !(current_user.admin? || current_user == comment.user) %>
         Anonymous
+      <!-- For Admins and comment author, display name and message that it was posted anonymously -->
       <% else %>
         <%= comment.user.name %>
         <% if comment.anonymous %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,7 +5,14 @@
     <br>
     <p>
       <strong>User:</strong>
-      <%= comment.user.name %>
+      <% if comment.anonymous && !(current_user.admin? || current_user == comment.user) %>
+        Anonymous
+      <% else %>
+        <%= comment.user.name %>
+        <% if comment.anonymous %>
+          (Posted as Anonymous)
+        <% end %>
+      <% end %>
     </p>
 
     <p>

--- a/db/migrate/20231022182814_add_anonymous_to_comments.rb
+++ b/db/migrate/20231022182814_add_anonymous_to_comments.rb
@@ -1,0 +1,5 @@
+class AddAnonymousToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :anonymous, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2023_10_14_055156) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_10_22_182814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +52,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_14_055156) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "admins", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "full_name"
+    t.string "uid"
+    t.string "avatar_url"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+  end
+
   create_table "announcements", force: :cascade do |t|
     t.string "title"
     t.datetime "timestamp"
@@ -70,6 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_14_055156) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "archived", default: false
+    t.boolean "anonymous", default: false
     t.index ["announcement_id"], name: "index_comments_on_announcement_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/spec/features/anon_comments_spec.rb
+++ b/spec/features/anon_comments_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.feature "Anonymous Comments", type: :feature do
+  let!(:member) { create(:user, first_name: 'first_name_1', last_name: 'last_name_1', access_level: 0, registration_completed: true) }
+  let!(:member2) { create(:user, first_name: 'First', last_name: 'Last', access_level: 0, registration_completed: true) }
+  let!(:admin) { create(:user, first_name: 'admin', last_name: 'admin', access_level: 1, registration_completed: true) }
+  let!(:announcement) { create(:announcement) }
+
+  # --- Sunny Day: Member adds anonymous Comment ---
+  it 'Member adds anonymous Comment' do
+    sign_in(member)
+    visit announcement_path(announcement)
+
+    fill_in "comment_box", with: "This is an anonymous comment"
+    check "Post anonymously"
+    click_on "Add Comment"
+
+    expect(page).to have_content("This is an anonymous comment")
+    expect(page).to have_content("Anonymous")
+
+    # Ensuring the original poster sees the name with anonymous tag
+    visit announcement_path(announcement)
+    expect(page).to have_content(member.name)
+    expect(page).to have_content("(Posted as Anonymous)")
+  end
+
+  # --- Rainy Day: Member can't see anonymous member name ---
+  it 'Member can not see anonymous member name' do
+    sign_in(member)
+    anon_comment = create(:comment, user: member2, announcement: announcement, anonymous: true)
+
+    visit announcement_path(announcement)
+
+    expect(page).to have_content("Anonymous")
+    expect(page).to(have_content(anon_comment.content))
+    expect(page).not_to have_content(member2.name)
+  end
+
+  # --- Sunny Day: Admin can see anonymous member name ---
+  it 'Admin can see anonymous member name' do
+    sign_in(admin)
+    anon_comment = create(:comment, user: member2, announcement: announcement, anonymous: true)
+
+    visit announcement_path(announcement)
+
+    expect(page).to have_content("(Posted as Anonymous)")
+    expect(page).to(have_content(anon_comment.content))
+    expect(page).to have_content(member2.name)
+  end
+
+  # --- Rainy Day: Admin can't post anonymous comment ---
+  it 'Admin can not post anonymous comment' do
+    sign_in(admin)
+    visit announcement_path(announcement)
+
+    expect(page).not_to have_selector("input[type=checkbox][name='comment[anonymous]']")
+  end
+
+end


### PR DESCRIPTION
The anonymous comment feature from an acceptance criterion in Sprint 2 was big enough to warrant an entire ticket for Sprint 3. This adds the feature, admin edge cases, and spec tests.